### PR TITLE
fix summary line

### DIFF
--- a/ecukes.el
+++ b/ecukes.el
@@ -1,5 +1,5 @@
 #!/usr/bin/env emacs --script
-;;; ecukes --- Cucumber for Emacs
+;;; ecukes.el --- Cucumber for Emacs
 
 ;; Copyright (C) 2010 Johan Andersson
 


### PR DESCRIPTION
also is the #! still required in ecukes.el? My tool finds the summary on the second line too but lm-summary from built-in lisp-mnt.el does not.
