### PR TITLE
Two empty lines in a py-string: a test and a tentative fix

### DIFF
--- a/ecukes-parse.el
+++ b/ecukes-parse.el
@@ -152,11 +152,11 @@
       (forward-line 1)
       (while (not (string-match-p ecukes-parse-py-string-re (ecukes-parse-line)))
         (let ((line (ecukes-parse-line)))
-          (if (<= whites (length line))
-              (add-to-list 'lines (substring line whites) t 'eq)
-            (add-to-list 'lines nil t 'eq)))
+          (push
+           (if (<= whites (length line)) (substring line whites) nil)
+           lines))
         (forward-line 1))
-      (mapconcat 'identity lines "\n"))))
+      (mapconcat 'identity (nreverse lines) "\n"))))
 
 (defun ecukes-parse-line (&optional strip-whitespace)
   "Parse current line."

--- a/test/ecukes-parse-py-string-step-test.el
+++ b/test/ecukes-parse-py-string-step-test.el
@@ -29,3 +29,11 @@
    (lambda (name type arg)
      (should (eq type 'py-string))
      (should (equal arg "Lorem ipsum\nLorem ipsum")))))
+
+(ert-deftest parse-py-string-step-two-empty-lines ()
+  "Should parse py string with several empty lines."
+  (with-parse-step
+   "py-string-two-empty-lines"
+   (lambda (name type arg)
+     (should (eq type 'py-string))
+     (should (equal arg "abc\n\ndef\n")))))

--- a/test/features/step/py-string-two-empty-lines.feature
+++ b/test/features/step/py-string-two-empty-lines.feature
@@ -1,0 +1,8 @@
+Scenario: Some scenario
+  Given this text:
+    """
+    abc
+
+    def
+
+    """


### PR DESCRIPTION
The fix should work (and print-debugging tells me it does), but I still couldn't manage to make the test pass. So feel free to consider this just a bug report.
