### PR TITLE
Handle when ECUKES_EMACS contains spaces

### DIFF
--- a/ecukes
+++ b/ecukes
@@ -33,7 +33,7 @@ fi
 if [ "$1" == "--graphical" ] ; then
     # create spec output file
     export ECUKES_OUTFILE=`mktemp /tmp/emacsoutput.XXXXX`
-    $ECUKES_EMACS --load "$ECUKES_EL" -q "${@:2}"
+    "$ECUKES_EMACS" --load "$ECUKES_EL" -q "${@:2}"
 
     # send that file to the console
     cat $ECUKES_OUTFILE
@@ -41,5 +41,5 @@ if [ "$1" == "--graphical" ] ; then
     # clean up
     rm $ECUKES_OUTFILE
 else
-    $ECUKES_EMACS --script $ECUKES_EL "$@"
+    "$ECUKES_EMACS" --script $ECUKES_EL "$@"
 fi


### PR DESCRIPTION
I have an Emacs on my system with a space in its pathname -- this commit lets ecukes use it correctly.
