### PR TITLE
Basic support for scenario outlines

### DIFF
--- a/ecukes-def.el
+++ b/ecukes-def.el
@@ -3,7 +3,7 @@
 
 (defstruct ecukes-feature
   "A feature is the top level structure for a feature file."
-  intro background scenarios)
+  intro background outlines scenarios)
 
 (defstruct ecukes-intro
   "A feature introduction is a description of a feature. It is
@@ -13,6 +13,10 @@ optional, but is conventionally included."
 (defstruct ecukes-background
   "A feature background is a few steps that are run before each scenario."
   steps)
+
+(defstruct ecukes-outline
+  "A scenario outline contains examples that are used to generate concrete scenarios."
+  name steps tags table)
 
 (defstruct ecukes-scenario
   "A feature scenario is a scenario that is built up by steps."

--- a/test/ecukes-parse-scenario-outline-test.el
+++ b/test/ecukes-parse-scenario-outline-test.el
@@ -1,0 +1,80 @@
+(require 'ecukes-parse)
+
+(defun with-parse-outline (name fn)
+  (let* ((feature-file (fixture-file-path "outlines" name))
+         (feature (ecukes-parse-feature feature-file))
+         (outlines (ecukes-feature-outlines feature))
+         (scenarios (ecukes-feature-scenarios feature)))
+    (funcall fn outlines scenarios)))
+
+(defun should-parse-outline (name expected-examples &optional tests)
+  (with-parse-outline
+   name
+   (lambda (outlines scenarios)
+     (should (= 1 (length outlines)))
+     (let* ((outline (car outlines))
+            (tags (ecukes-outline-tags outline))
+            (table (ecukes-outline-table outline)))
+       (should (equal expected-examples (1- (length table))))
+       (should (equal expected-examples (length scenarios)))
+       (should (-all? (lambda (scenario) (equal tags (ecukes-scenario-tags scenario))) scenarios))
+       (when (functionp tests) (funcall tests (car outlines) scenarios))))))
+
+(ert-deftest parse-outline-no-examples ()
+  "Should parse scenario outlines with no examples."
+  (with-parse-outline
+   "no-examples"
+   (lambda (outlines scenarios)
+     (should (= 1 (length outlines)))
+     (should-not (ecukes-outline-table (car outlines)))
+     (should (= 0 (length scenarios))))))
+
+(ert-deftest parse-outline-one-example ()
+  "Should parse scenario outline with one example."
+  (should-parse-outline
+   "one-example" 1
+   (lambda (outline scenarios)
+     (should (ecukes-outline-table outline))
+     (should (= 1 (length scenarios))))))
+
+(ert-deftest parse-outline-multiple-examples ()
+  "Should parse scenario outlines with multiple examples."
+  (should-parse-outline "multiple-examples" 3))
+
+(ert-deftest parse-outline-tags ()
+  "Should parse scenario outlines with tags."
+  (should-parse-outline "tags" 2))
+
+(ert-deftest parse-outline-background ()
+  "Should parse scenario outlines with backgrounds."
+  (should-parse-outline "background" 1))
+
+(ert-deftest parse-outline-bad-indents ()
+  "Should parse scenario outlines with bad indentation."
+  (should-parse-outline "bad-indents" 2))
+
+(ert-deftest parse-outline-substitution ()
+  "Should substitute the values from examples into the generated scenarios."
+  (should-parse-outline
+   "substitution" 3
+   (lambda (outline scenarios)
+     (let* ((scenario (car scenarios))
+            (simple-step (car (ecukes-scenario-steps scenario)))
+            (py-step (nth 1 (ecukes-scenario-steps scenario)))
+            (table-step (nth 2 (ecukes-scenario-steps scenario))))
+       (should (string= "Given I want to marry" (ecukes-step-name simple-step)))
+       (should (string= "I want to marry" (ecukes-step-body simple-step)))
+       (should-not (ecukes-step-arg simple-step))
+
+       (should (string= "You are great! I want to marry you." (ecukes-step-arg py-step)))
+
+       (should (equal '(("response" "desired") ("positive" "true"))
+                      (ecukes-step-arg table-step)))))))
+
+(ert-deftest parse-outline-wrong-column-names ()
+  "Generates scenarios without any substitutions if your column names are wrong."
+  (should-parse-outline
+   "wrong-column-names" 1
+   (lambda (outline scenarios)
+     (let ((step (car (ecukes-scenario-steps (car scenarios)))))
+       (should (string= "Given <foo> is <bar>" (ecukes-step-name step)))))))

--- a/test/fixtures/outlines/background.feature
+++ b/test/fixtures/outlines/background.feature
@@ -1,0 +1,11 @@
+Feature: scenario outlines
+
+  Background:
+    Given I do something
+
+  Scenario Outline: with background
+    Given <foo> is <bar>
+
+    Examples:
+      | foo | bar |
+      | 1   | 2   |

--- a/test/fixtures/outlines/bad-indents.feature
+++ b/test/fixtures/outlines/bad-indents.feature
@@ -1,0 +1,9 @@
+Feature: scenario outlines
+
+  Scenario Outline: weird indents
+    Given <foo> is <bar>
+
+  Examples:
+  | foo |     bar |
+    | 1 | 2 |
+ | 3         |   4|

--- a/test/fixtures/outlines/multiple-examples.feature
+++ b/test/fixtures/outlines/multiple-examples.feature
@@ -1,0 +1,10 @@
+Feature: scenario outline
+
+  Scenario Outline: multiple examples
+    Given <foo> is <bar>
+
+    Examples:
+      | foo | bar |
+      | 1   | 2   |
+      | 3   | 4   |
+      | 5   | 6   |

--- a/test/fixtures/outlines/no-examples.feature
+++ b/test/fixtures/outlines/no-examples.feature
@@ -1,0 +1,4 @@
+Feature: scenario outlines
+
+  Scenario Outline: no examples
+    Given <foo> is <bar>

--- a/test/fixtures/outlines/one-example.feature
+++ b/test/fixtures/outlines/one-example.feature
@@ -1,0 +1,8 @@
+Feature: scenario outlines
+
+  Scenario Outline: single example given
+    Given <foo> is <bar>
+
+    Examples:
+      | foo | bar |
+      | 1   | 2   |

--- a/test/fixtures/outlines/substitution.feature
+++ b/test/fixtures/outlines/substitution.feature
@@ -1,0 +1,17 @@
+Feature: scenario outlines
+
+  Scenario Outline: py-string and table substitution
+    Given I want to <activity>
+    When I say:
+      """
+      You are <compliment>! I want to <activity> you.
+      """
+    Then the results are:
+      | response   | desired   |
+      | <response> | <desired> |
+
+    Examples:
+      | activity | compliment | response | desired |
+      | marry    | great      | positive | true    |
+      | marry    | not bad    | negative | false   |
+      | divorce  | an idiot   | negative | true    |

--- a/test/fixtures/outlines/tags.feature
+++ b/test/fixtures/outlines/tags.feature
@@ -1,0 +1,10 @@
+Feature: scenario outlines
+
+  @regression @ui
+  Scenario Outline: with tags
+    Given <foo> is <bar>
+
+    Examples:
+      | foo | bar |
+      | 1   | 2   |
+      | 3   | 4   |

--- a/test/fixtures/outlines/wrong-column-names.feature
+++ b/test/fixtures/outlines/wrong-column-names.feature
@@ -1,0 +1,8 @@
+Feature: scenario outlines
+
+  Scenario Outline: wrong column names
+    Given <foo> is <bar>
+
+    Examples:
+      | baz | quux |
+      | 1   | 2    |


### PR DESCRIPTION
See issue #26.

The primary shortcoming of this implementation is that it generates scenarios using the outlines at parse-time, which results in the ecukes output being the scenarios rather than the outlines that cucumber proper would print out.

But if you really want scenario outlines, like I did, this is better than nothing! I've got a very young new project [swallow-window.el](https://github.com/pd/swallow-window.el) that I wanted to drive with ecukes features; it's just vastly easier to read the tests than the corresponding ert-style tests.

The ecukes in that project don't currently point at this fork, but you can of course just alter the Makefile to point at the right ecukes bin if you want to see a working example of these scenario outlines.
