### PR TITLE
Replaced regex pattern with glob pattern as an argument to f-glob.

### DIFF
--- a/ecukes.el
+++ b/ecukes.el
@@ -39,7 +39,7 @@
   (let ((feature-files
          (if (and (buffer-file-name) (s-matches? "\.feature$" (buffer-file-name)))
              (list (buffer-file-name))
-           (f-glob "\\.feature$" (ecukes-project-features-path)))))
+           (f-glob "*.feature" (ecukes-project-features-path)))))
     (let ((ecukes-buffer (get-buffer-create ecukes-buffer-name))
           (buffers (buffer-list))
           (ecukes-internal-message-log)


### PR DESCRIPTION
In absence of this change, f-glob would form a call to file-expand-wildcards with argument "(ecukes-project-path)/features/\.feature$", which would be looked up literally and fail to provide list of .feature files in project tree.
