### PR TITLE
Added namespace to occurences of symbol `features'

### DIFF
--- a/ecukes-helpers.el
+++ b/ecukes-helpers.el
@@ -3,19 +3,19 @@
 (require 'dash)
 (require 'ecukes-def)
 
-(defun ecukes-feature-steps (features)
+(defun ecukes-feature-steps (ecukes-features)
   "Return all steps in all FEATURES."
   (let* ((scenarios
           (-flatten
            (-map
             (lambda (feature)
-              (ecukes-feature-scenarios feature)) features)))
+              (ecukes-feature-scenarios feature)) ecukes-features)))
          (backgrounds
           (-reject
            'null
            (-map
             (lambda (feature)
-              (ecukes-feature-background feature)) features)))
+              (ecukes-feature-background feature)) ecukes-features)))
          (scenario-steps
           (-map
            (lambda (scenario)

--- a/ecukes-run.el
+++ b/ecukes-run.el
@@ -23,20 +23,20 @@
 
 (defun ecukes-run (feature-files)
   "Parse and run FEATURE-FILES if no steps are missing."
-  (let* ((features (-map 'ecukes-parse-feature feature-files))
+  (let* ((ecukes-features (-map 'ecukes-parse-feature feature-files))
          (steps-without-definition
-          (ecukes-steps-without-definition (ecukes-feature-steps features))))
+          (ecukes-steps-without-definition (ecukes-feature-steps ecukes-features))))
     (cond (steps-without-definition
            (run-hook-with-args 'ecukes-reporter-steps-without-definition-hook steps-without-definition))
           (:else
-           (let ((features (length features))
-                 (scenarios (length (-flatten (-map 'ecukes-feature-scenarios features)))))
+           (let ((ecukes-features (length ecukes-features))
+                 (scenarios (length (-flatten (-map 'ecukes-feature-scenarios ecukes-features)))))
              (run-hook-with-args
               'ecukes-reporter-start-hook
-              `((features . ,features)
+              `((ecukes-features . ,ecukes-features)
                 (scenarios . ,scenarios))))
            (ecukes-hooks-run-setup)
-           (ecukes-run-features features)
+           (ecukes-run-features ecukes-features)
            (ecukes-hooks-run-teardown)
            (run-hook-with-args
             'ecukes-reporter-end-hook
@@ -48,13 +48,13 @@
               (steps-failed     . ,ecukes-stats-steps-failed)
               (steps-skipped    . ,ecukes-stats-steps-skipped)))))))
 
-(defun ecukes-run-features (features)
+(defun ecukes-run-features (ecukes-features)
   "Run FEATURES."
   (-each
-   features
+   ecukes-features
    (lambda (feature)
-     (let ((first (eq (-first-item features) feature))
-           (last (eq (-last-item features) feature)))
+     (let ((first (eq (-first-item ecukes-features) feature))
+           (last (eq (-last-item ecukes-features) feature)))
        (when first
          (run-hook-with-args 'ecukes-reporter-before-first-feature-hook feature))
        (when last

--- a/test/ecukes-run-test.el
+++ b/test/ecukes-run-test.el
@@ -34,7 +34,7 @@
     (let (hook-has-run)
       (add-hook 'ecukes-reporter-start-hook
                 (lambda (stats)
-                  (should (equal stats '((features . 2) (scenarios . 4))))
+                  (should (equal stats '((ecukes-features . 2) (scenarios . 4))))
                   (setq hook-has-run t)))
       (ecukes-run '(feature-file-1 feature-file-2))
       (should hook-has-run)))))


### PR DESCRIPTION
Built-in symbol `features', most often reliant for information of present capabilities of emacs runtime, was being shadowed by local dynamic binding, under the scope of a few routines. 

Resultant changes were determined after a simple grep search and dismissing those occurrences which were part of another symbol, a string or a comment. 

Although no thorough examination of context of affected code has been made, building procedure does not indicate any downfalls which set of automated tests would be able to determine.
