### PR TITLE
Skip feature with nil intro

### DIFF
--- a/ecukes-reporter.el
+++ b/ecukes-reporter.el
@@ -230,15 +230,14 @@ The rest of the arguments will be applied to `format'."
 
 (defun ecukes-reporter-print-feature-header (feature)
   "Print FEATURE and description if any."
-  (let ((intro (ecukes-feature-intro feature)))
-    (when intro
-      (let* ((header (ecukes-intro-header intro))
-             (description (ecukes-intro-description intro))
-             (scenarios (ecukes-feature-scenarios feature)))
-        (ecukes-reporter-println "Feature: %s" header)
-        (--each description (ecukes-reporter-println 2 it))
-        (when description
-          (ecukes-reporter-print-newline))))))
+  (-when-let (intro (ecukes-feature-intro feature))
+    (let* ((header (ecukes-intro-header intro))
+           (description (ecukes-intro-description intro))
+           (scenarios (ecukes-feature-scenarios feature)))
+      (ecukes-reporter-println "Feature: %s" header)
+      (--each description (ecukes-reporter-println 2 it))
+      (when description
+        (ecukes-reporter-print-newline)))))
 
 (defun ecukes-reporter-print-background-header ()
   "Print background header."

--- a/features/ecukes.feature
+++ b/features/ecukes.feature
@@ -111,3 +111,14 @@ Feature: Ecukes
       2 scenarios (0 failed, 2 passed)
       0 steps
       """
+
+  Scenario: Run empty feature
+    Given feature "foo":
+      """
+      """
+    When I run ecukes "features/foo.feature --reporter magnars"
+    Then I should see command output:
+      """
+      0 scenarios
+      0 steps
+      """


### PR DESCRIPTION
Prevents from "Wrong type argument: arrayp, nil" error in case of empty feature file.

This is the fix for "Allow empty feature files #130" issue.
