### PR TITLE
Minor typo: "buffer-name", not "buffer-nane"

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -285,7 +285,7 @@ The corresponding step definition is:
 
 ```
 (Given "I am in buffer \"\\(.+\\)\""
-  (lambda (buffer-nane)
+  (lambda (buffer-name)
     ;; ...
     ))
 ```


### PR DESCRIPTION
Fix a minor typo.
