### PR TITLE
Test ecukes with emacs 25.2 pretest on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
   - EVM_EMACS=emacs-24.4-travis
   - EVM_EMACS=emacs-24.5-travis
   - EVM_EMACS=emacs-25.1-travis
+  - EVM_EMACS=emacs-25.2-travis
 script:
   - emacs --version
   - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
   - EVM_EMACS=emacs-24.4-travis
   - EVM_EMACS=emacs-24.5-travis
   - EVM_EMACS=emacs-25.1-travis
-  - EVM_EMACS=emacs-25.2-travis
+  - EVM_EMACS=emacs-git-snapshot-travis
 script:
   - emacs --version
   - make test


### PR DESCRIPTION
I think this might fail the tests.

I'm using ecukes with 25.2 at the moment and every test I write "passes" even when they should fail. :sob: 