### PR TITLE
Possible fix for #159 (without affecting emacs internals)

### DIFF
--- a/features/error-log.feature
+++ b/features/error-log.feature
@@ -35,3 +35,33 @@ Feature: Error Log
         /(1 0)
         (lambda nil (/ 1 0))()
       """
+
+
+  # Emacs 25.1 and 25.2 added weird behaviour in cl-assert which broke ecukes
+  # when it was used to assert in tests.
+  @now
+  Scenario: Using cl-assert
+    Given step definition:
+      """
+      (Then "^asserting false$"
+        (lambda () (cl-assert (= 1 2))))
+      """
+    Given feature "cl-assert":
+      """
+      Feature: cl-assert
+
+        Scenario: Asserting
+          Then asserting false
+      """
+    When I run ecukes "features/cl-assert.feature --reporter spec"
+    Then I should see command error:
+      """
+      Feature: cl-assert
+
+        Scenario: Asserting
+          Then asserting false
+            Assertion failed: (= 1 2)
+
+      1 scenarios (1 failed, 0 passed)
+      1 steps (1 failed, 0 skipped, 0 passed)
+      """


### PR DESCRIPTION
This seems to fix the bug, but it introduces another (less critical bug): error messages used with cl-assert won't show up correctly (only the form that failed will appear). It looks like it's impossible to work around that without modifying `cl--assertion-failed` because when `debug-on-error` is enabled it completely throws away the `arg` variable, which contains the data needed to format the error messages!

I'll make an alternative PR in a few minutes which uses a more intrusive approach, but fixes this problem.