### PR TITLE
Fix #159 (includes fixing error messages, but advises emacs core function)

### DIFF
--- a/ecukes-cli.el
+++ b/ecukes-cli.el
@@ -27,6 +27,17 @@
 (setq debug-on-signal t)
 (setq debugger 'ecukes-debug)
 
+;; This little hack fixes a bug in emacs 25.2 where cl-assert (which is used
+;; internally by espuds) was changed to call the debugger directly when
+;; debug-on-error is enabled (instead of signalling an error). This meant that a
+;; condition-case used by ecukes to detect errors was never hit, so ecukes never
+;; reported any errors. See #159.
+(defun ecukes-suppress-debug-on-error (orig-fun &rest args)
+  (let ((debug-on-error nil))
+    (apply orig-fun args)))
+(when (and (= emacs-major-version 25) (= emacs-minor-version 2))
+  (advice-add 'cl--assertion-failed :around #'ecukes-suppress-debug-on-error))
+
 (defvar ecukes-include-tags nil
   "Scenario tags to include.")
 

--- a/features/error-log.feature
+++ b/features/error-log.feature
@@ -35,3 +35,32 @@ Feature: Error Log
         /(1 0)
         (lambda nil (/ 1 0))()
       """
+
+
+  # Emacs 25.1 and 25.2 added weird behaviour in cl-assert which broke ecukes
+  # when it was used to assert in tests.
+  Scenario: Using cl-assert
+    Given step definition:
+      """
+      (Then "^asserting false$"
+        (lambda () (cl-assert (= 1 2) nil "Expected 1 to equal %s" "2")))
+      """
+    Given feature "cl-assert":
+      """
+      Feature: cl-assert
+
+        Scenario: Asserting
+          Then asserting false
+      """
+    When I run ecukes "features/cl-assert.feature --reporter spec"
+    Then I should see command error:
+      """
+      Feature: cl-assert
+
+        Scenario: Asserting
+          Then asserting false
+            Expected 1 to equal 2
+
+      1 scenarios (1 failed, 0 passed)
+      1 steps (1 failed, 0 skipped, 0 passed)
+      """


### PR DESCRIPTION
This gives proper errors unlike the other fixes, but requires advising a function outside of ecukes.