### PR TITLE
Fix interpretation of % in step as interpolation triggering error:

### DIFF
--- a/ecukes-reporter.el
+++ b/ecukes-reporter.el
@@ -298,7 +298,7 @@ The rest of the arguments will be applied to `format'."
           (cond ((eq status 'success) 'ansi-green)
                 ((eq status 'failure) 'ansi-red)
                 ((eq status 'skipped) 'ansi-cyan))))
-    (ecukes-reporter-println 4 (funcall color (replace-regexp-in-string "%" "%%%%" name)))
+    (ecukes-reporter-println 4 (funcall color (s-replace "%" "%%%%" name)))
     (when (eq type 'table)
       (ecukes-reporter-print-table step))
     (when (eq type 'py-string)

--- a/ecukes-reporter.el
+++ b/ecukes-reporter.el
@@ -298,7 +298,7 @@ The rest of the arguments will be applied to `format'."
           (cond ((eq status 'success) 'ansi-green)
                 ((eq status 'failure) 'ansi-red)
                 ((eq status 'skipped) 'ansi-cyan))))
-    (ecukes-reporter-println 4 (funcall color name))
+    (ecukes-reporter-println 4 (funcall color (replace-regexp-in-string "%" "%%%%" name)))
     (when (eq type 'table)
       (ecukes-reporter-print-table step))
     (when (eq type 'py-string)


### PR DESCRIPTION
Fix interpretation of % in step as interpolation triggering error:
`Not enough arguments for format string`