### PR TITLE
Apply cl--assertion failure workaround to all emacs 25.x versions

### DIFF
--- a/ecukes-cli.el
+++ b/ecukes-cli.el
@@ -27,15 +27,16 @@
 (setq debug-on-signal t)
 (setq debugger 'ecukes-debug)
 
-;; This little hack fixes a bug in emacs 25.2 where cl-assert (which is used
-;; internally by espuds) was changed to call the debugger directly when
-;; debug-on-error is enabled (instead of signalling an error). This meant that a
-;; condition-case used by ecukes to detect errors was never hit, so ecukes never
-;; reported any errors. See #159.
+;; This little hack fixes various related bugs in emacs 25 caused by changes to
+;; cl-assert. The main issue was that cl-assert (which is used internally by
+;; espuds) was changed to call the debugger directly when debug-on-error is
+;; enabled (instead of signalling an error). This meant that a condition-case
+;; used by ecukes to detect errors was never hit, so ecukes never reported any
+;; errors. See #159. Hopefully cl-assert will work sensibly again by emacs 26!
 (defun ecukes-suppress-debug-on-error (orig-fun &rest args)
   (let ((debug-on-error nil))
     (apply orig-fun args)))
-(when (and (= emacs-major-version 25) (= emacs-minor-version 2))
+(when (and (= emacs-major-version 25))
   (advice-add 'cl--assertion-failed :around #'ecukes-suppress-debug-on-error))
 
 (defvar ecukes-include-tags nil


### PR DESCRIPTION
I'm just creating this as a PR to run the Travis tests. I'll merge it if they pass.