### PR TITLE
Consider .ecukes when looking for window related parameters

### DIFF
--- a/bin/ecukes
+++ b/bin/ecukes
@@ -46,6 +46,11 @@ function has_option {
   for opt in "${@:2}"; do
     [[ "$opt" == "$1" ]] && return 0;
   done
+  if [[ -e ".ecukes" ]] ; then
+      for fileopt in $(cat ".ecukes") ; do
+          [[ "$fileopt" == "$1" ]] && return 0;
+      done
+  fi
   return 1
 }
 


### PR DESCRIPTION
Adding --win or --no-win to .ecukes previously made no difference
since they are read by bin/ecukes.

I could not find any tests for bin/ecukes.
