### PR TITLE
DWIM under --debug; Test the working tree, not latest MELPA

### DIFF
--- a/Cask
+++ b/Cask
@@ -2,6 +2,7 @@
 (source melpa)
 
 (package "ecukes" "0.6.15" "Cucumber for Emacs.")
+(files "ecukes*" "templates" "bin" "reporters")
 
 (depends-on "f" "0.11.0")
 (depends-on "s" "1.8.0")

--- a/Makefile
+++ b/Makefile
@@ -9,16 +9,14 @@ FEATURES = $(wildcard features/*.feature features/reporters/*.feature)
 
 all: test
 
-test: clean-elc
-	$(MAKE) unit-test
-	$(MAKE) ecukes
-	$(MAKE) compile
+test: clean-elc unit-test ecukes compile
 
 unit-test: elpa
-	$(CASK) exec ert-runner
+	$(CASK) exec ert-runner -L test -L . test/ecukes*.el
 
 elpa: $(PKG_DIR)
 $(PKG_DIR): Cask
+	$(CASK) link ecukes .
 	$(CASK) install
 	touch $@
 

--- a/ecukes-cli.el
+++ b/ecukes-cli.el
@@ -24,7 +24,6 @@
   (defvar ecukes-error-log-file))
 
 (setq debug-on-error t)
-(setq debug-on-signal t)
 (setq debugger 'ecukes-debug)
 
 ;; This little hack fixes various related bugs in emacs 25 caused by changes to
@@ -131,7 +130,7 @@ A tag starting with ~ excluded from the scenarios."
 (defun ecukes-cli/run (&rest args)
   (ecukes-load)
   (ecukes-reporter-use ecukes-cli-reporter)
-  (let ((feature-files))
+  (let (feature-files)
     (-each
      args
      (lambda (arg)

--- a/ecukes-pkg.el
+++ b/ecukes-pkg.el
@@ -1,4 +1,4 @@
-(define-package "ecukes" "0.6.10" "Cucumber for Emacs."
+(define-package "ecukes" "0.7.0" "Cucumber for Emacs."
   '((commander "0.6.1")
     (espuds "0.2.2")
     (ansi "0.3.0")

--- a/test/ecukes-run-test.el
+++ b/test/ecukes-run-test.el
@@ -764,7 +764,8 @@
           :fn
           (lambda ()
             (error "*- boom -*"))))
-   (should-not (ecukes-run-step (make-ecukes-step)))))
+   (let ((debug-on-error nil))
+     (should-not (ecukes-run-step (make-ecukes-step))))))
 
 (ert-deftest ecukes-run-test/run-step-error-message ()
   (with-mock
@@ -774,7 +775,8 @@
           :fn
           (lambda ()
             (error "*- boom -*"))))
-   (let ((step (make-ecukes-step)))
+   (let ((step (make-ecukes-step))
+         (debug-on-error nil))
      (should-not (ecukes-run-step step))
      (should (equal (ecukes-step-err step) "*- boom -*")))))
 
@@ -793,7 +795,8 @@
           :fn
           (lambda ()
             (error "*- boom -*"))))
-   (should-not (ecukes-run-step (make-ecukes-step)))))
+   (let ((debug-on-error nil))
+     (should-not (ecukes-run-step (make-ecukes-step))))))
 
 (ert-deftest ecukes-run-test/run-step-keyboard-quit ()
   (with-mock
@@ -844,7 +847,8 @@
           (lambda (callback)
             ;; not callbacked
             )))
-   (let ((step (make-ecukes-step)))
+   (let ((step (make-ecukes-step))
+         (debug-on-error nil))
      (should-not
       (ecukes-run-step step))
      (let ((expected "Did not callback async step within 0.1 seconds")

--- a/test/ecukes-test.el
+++ b/test/ecukes-test.el
@@ -19,8 +19,6 @@
 (unless (require 'ert nil 'noerror)
   (require 'ert (f-expand "ert" ecukes-test/vendor-path)))
 
-(setq debug-on-entry t)
-(setq debug-on-error t)
 (setq ecukes-include-tags nil)
 (setq ecukes-verbose t)
 (setq ecukes-path ecukes-test/root-path)


### PR DESCRIPTION
The debugger is not reentrant, and invoking --debug at cli uselessly
produced a backtrace for the condition-case call in
`custom-initialize-reset` (because debug-on-signal is true).

Turn off debug-on-signal, and use `condition-case-unless-debug` in
`ecukes-run-step` to get a useful backtrace on the first substantive
error under `--debug`.

Use `cask link` to test the working tree, and not the latest tree on
melpa (as gotten by `cask install`).

Closes #175.