### PR TITLE
"Zero or more occurrences" regex

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ env:
   - EVM_EMACS=emacs-25.3-travis
   - EVM_EMACS=emacs-26.1-travis
   - EVM_EMACS=emacs-26.2-travis
+  - EVM_EMACS=emacs-git-snapshot-travis
+matrix:
+  allow_failures:
+    - env: EVM_EMACS=emacs-git-snapshot-travis
 
 script:
   - emacs --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,8 @@ env:
   - EVM_EMACS=emacs-25.1-travis
   - EVM_EMACS=emacs-25.2-travis
   - EVM_EMACS=emacs-25.3-travis
-  - EVM_EMACS=emacs-git-snapshot-travis
-matrix:
-  allow_failures:
-    - env: EVM_EMACS=emacs-git-snapshot-travis
+  - EVM_EMACS=emacs-26.1-travis
+  - EVM_EMACS=emacs-26.2-travis
 
 script:
   - emacs --version

--- a/Cask
+++ b/Cask
@@ -1,7 +1,7 @@
 (source gnu) ; for cl-lib
 (source melpa)
 
-(package "ecukes" "0.6.15" "Cucumber for Emacs.")
+(package-descriptor "ecukes-pkg.el")
 (files "ecukes*" "templates" "bin" "reporters")
 
 (depends-on "f" "0.11.0")

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ unit-test: elpa
 
 elpa: $(PKG_DIR)
 $(PKG_DIR): Cask
-	$(CASK) link ecukes .
 	$(CASK) install
+	$(CASK) link ecukes .
 	touch $@
 
 compile: $(ELC)

--- a/ecukes-cli.el
+++ b/ecukes-cli.el
@@ -35,7 +35,7 @@
 (defun ecukes-suppress-debug-on-error (orig-fun &rest args)
   (let ((debug-on-error nil))
     (apply orig-fun args)))
-(when (and (or (= emacs-major-version 25) (= emacs-major-version 26)))
+(when (>= emacs-major-version 25)
   (advice-add 'cl--assertion-failed :around #'ecukes-suppress-debug-on-error))
 
 (defvar ecukes-include-tags nil

--- a/test/ecukes-steps-test.el
+++ b/test/ecukes-steps-test.el
@@ -35,6 +35,40 @@
    (Given "^a known state$" (lambda () "x"))
    (should (equal (Given "a known state") "x"))))
 
+(ert-deftest steps-call-step-optional-argument ()
+  "Should call step with optional argument (and not treat it as a callback if omittted)."
+  (with-steps
+   (Given "^a \\(un\\)?known state$" (lambda (x) x))
+   (should (null (Given "a known state")))
+   (should (equal (Given "a unknown state") "un"))))
+
+(ert-deftest steps-call-step-optional-and-single-argument ()
+  "Should call step with optional argument and another argument."
+  (with-steps
+   (Given "^a \\(un\\)?known \\(quantity\\|state\\)$" (lambda (x y) (concat x y)))
+   (should (equal (Given "a known quantity") "quantity"))
+   (should (equal (Given "a unknown quantity") "unquantity"))))
+
+(ert-deftest steps-call-step-tickle1-optional-argument ()
+  "Tickle optional regex."
+  (with-steps
+   (Given "bar\\(fab\\)?\\(foo\\)?\\(fuz\\)? buck\\(faz\\)?$" (lambda (w x y z) (list w x y  z)))
+   (should (equal (Given "barfoo buckfaz") '(nil "foo" nil "faz")))))
+
+(ert-deftest steps-call-step-tickle2-optional-argument ()
+  "Tickle optional regex."
+  (with-steps
+   (Given "bar\\(fab\\)?\\(foo\\)?\\(fuz\\)? buck\\(faz\\)?" (lambda (w x y z) (list w x y z)))
+   (should (equal (Given "barfoo buckfaz fabio") '(nil "foo" nil "faz")))))
+
+(ert-deftest steps-call-step-tickle3-optional-argument ()
+  "Tickle optional regex."
+  (with-steps
+   (with-mock
+    (mock (error (ansi-red "Step not defined: `barfoo buckfaz fabio`")) :times 1)
+    (Given "bar\\(fab\\)?\\(foo\\)?\\(fuz\\)? buck\\(faz\\)?$" #'ignore)
+    (Given "barfoo buckfaz fabio"))))
+
 (ert-deftest steps-call-step-single-argument ()
   "Should call step with single argument."
   (with-steps


### PR DESCRIPTION
Matching a step like
```
Given a known state
```
against a step definition like
```
(Given "^a \\(un\\)?known state$" (lambda (x) x))
```
currently results in `x` erroneously being treated as a callback via the async assumption.  What we really want is `x` to be nil.