### PR TITLE
Revert "Zero or More Occurrences" Regex

### DIFF
--- a/ecukes-steps.el
+++ b/ecukes-steps.el
@@ -95,16 +95,7 @@ When *calling* a step, argument takes the following form:
   (let* ((body (ecukes-step-body step))
          (step-def (ecukes-steps-find body)))
     (if step-def
-        (let* ((step-def-regex (ecukes-step-def-regex step-def))
-               (strict-regex (replace-regexp-in-string "\$?$"
-                                                       "\\\\(\\\\)"
-                                                       step-def-regex)))
-          ;; Matching "(foo)?bar" on "bar" results in nil when we want (nil)
-          ;; Matching "foo(bar)?" on "foo" results in nil when we want (nil)
-          ;; Matching "foo(bar)?(baz)?" on "foobar" results in (bar) when we want (bar nil)
-          ;; All is well if we append a zero-length match, e.g., "foo(bar)?(baz)?()"
-          ;; But watch out for eol anchor, so, "foo(bar)?()$" and not "foo(bar)?$()" !!!
-          (cdr (nbutlast (s-match strict-regex body))))
+        (cdr (s-match (ecukes-step-def-regex step-def) body))
       (loop for sub on (cdr (split-string body "\""))
             by (function cddr)
             collect (car sub)))))

--- a/test/ecukes-steps-test.el
+++ b/test/ecukes-steps-test.el
@@ -35,6 +35,23 @@
    (Given "^a known state$" (lambda () "x"))
    (should (equal (Given "a known state") "x"))))
 
+(ert-deftest steps-call-pystring-argument ()
+  "Should correctly parse pystring argument."
+  (with-steps
+   (Given "^I insert\\(?: \"\\(.+\\)\"\\|:\\)$"
+          (lambda (contents) contents))
+   (with-temp-buffer
+     (insert "Given I insert:
+\"\"\"
+howdy
+doody
+\"\"\"
+")
+     (goto-char (point-min))
+     (let ((step (ecukes-parse-step)))
+       (should (string= (ecukes-step-arg step) "howdy
+doody"))))))
+
 (ert-deftest steps-call-step-optional-argument ()
   "Should call step with optional argument (and not treat it as a callback if omittted)."
   :expected-result :failed

--- a/test/ecukes-steps-test.el
+++ b/test/ecukes-steps-test.el
@@ -37,6 +37,7 @@
 
 (ert-deftest steps-call-step-optional-argument ()
   "Should call step with optional argument (and not treat it as a callback if omittted)."
+  :expected-result :failed
   (with-steps
    (Given "^a \\(un\\)?known state$" (lambda (x) x))
    (should (null (Given "a known state")))


### PR DESCRIPTION
I broke pystring steps in #177 .  Sorry.

This PR reverts #177 and adds a weak pystring parsing test.

Fixes #178 