### PR TITLE
don't load env.el twice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: generic
+dist: trusty
 before_install:
   - curl -fsSkL https://gist.github.com/rejeep/ebcd57c3af83b049833b/raw > x.sh && source ./x.sh
   - evm install $EVM_EMACS --use --skip

--- a/ecukes-load.el
+++ b/ecukes-load.el
@@ -21,10 +21,16 @@
   "Load project support files."
   (let* ((env-file (f-expand "env" (ecukes-project-support-path)))
          (support-files
-          (f-files (ecukes-project-support-path)
-                   (lambda (file)
-                     (not (f-same? env-file file))))))
-    (load env-file nil t)
+          (let* ((get-root
+                  (lambda (y)
+                    (--min-by (> (length it) (length other))
+                              (mapcar (lambda (x)
+                                        (replace-regexp-in-string
+                                         (concat (regexp-quote x) "$") "" y))
+                                      (get-load-suffixes)))))
+                 (-compare-fn (lambda (x y)
+                                (string= (funcall get-root x) (funcall get-root y)))))
+            (-distinct (cons env-file (f-files (ecukes-project-support-path)))))))
     (--each support-files
       (load it nil t))))
 

--- a/test/ecukes-load-test.el
+++ b/test/ecukes-load-test.el
@@ -26,6 +26,31 @@
      '("/path/to/project/features/support/env.el"
        "/path/to/project/features/support/foo.el"
        "/path/to/project/features/support/bar.el"))
+    (mock (load * nil t) :times 3)
+    (ecukes-load-support))))
+
+(ert-deftest ecukes-load/support-load-env-once ()
+  (with-mock
+   (with-project
+    (stub expand-file-name => "/path/to/project/features/support/env.el")
+    (stub
+     f-files =>
+     '("/path/to/project/features/support/env.el"))
+    (mock (load * nil t) :times 1)
+    (ecukes-load-support))))
+
+(ert-deftest ecukes-load/support-load-tickle ()
+  (with-mock
+   (with-project
+    (stub expand-file-name => "/path/to/project/features/support/env.el")
+    (stub
+     f-files =>
+     '("/path/to/project/features/support/elc.gz"
+       "/path/to/project/features/support/foo.el"
+       "/path/to/project/features/support/foo.el.gz"
+       "/path/to/project/features/support/foo"
+       "/path/to/project/features/support/bar.elc"
+       "/path/to/project/features/support/bar.el"))
     (mock (load * nil t) :times 4)
     (ecukes-load-support))))
 
@@ -50,4 +75,3 @@
       "/path/to/project/features/step-definitions/misc-steps.el"))
    (mock (load * nil t) :times 2)
    (ecukes-load-step-definitions)))
-


### PR DESCRIPTION
If you name the env file `env.el`, it will now load only once.

If you have both `env` and `env.el` files, it will only load `env.el`.