### PR TITLE
ci: Use Eask for CI tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,13 +17,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        emacs_version: [24.5, 25.3, 26.3, 27.1]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        emacs_version:
+          - 26.3
+          - 27.2
+          - 28.2
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
 
-    - uses: purcell/setup-emacs@master
+    - uses: jcs090218/setup-emacs@master
       with:
         version: ${{ matrix.emacs_version }}
 
@@ -37,38 +40,13 @@ jobs:
         path: ~/.emacs.d
         key: emacs.d
 
-    - uses: actions/cache@v1
+    - uses: jcs090218/setup-emacs@master
       with:
-        path: ~/.cask
-        key: cask-000
+        version: ${{ matrix.emacs-version }}
 
-    - name: paths
-      run: |
-        echo "$HOME/local/bin" >> $GITHUB_PATH
-        echo "$HOME/local/cask/bin" >> $GITHUB_PATH
-        echo "$HOME/.local/bin" >> $GITHUB_PATH
-        echo "LD_LIBRARY_PATH=$HOME/.local/lib" >> $GITHUB_ENV
-
-    - name: apt-get
-      if: startsWith(runner.os, 'Linux')
-      run: |
-        sudo apt-get -yq update
-        DEBIAN_FRONTEND=noninteractive sudo apt-get -yq install gnutls-bin sharutils gnupg2 dirmngr libreadline-dev libcurl4-openssl-dev virtualenv
-
-    - name: gnupg
-      if: startsWith(runner.os, 'macOS')
-      run: brew list gnupg &>/dev/null || HOMEBREW_NO_AUTO_UPDATE=1 brew install gnupg
-
-    - name: versions
-      run: |
-        curl --version
-        emacs --version
-        gpg --version
-
-    - name: cask
-      run: |
-        sh tools/install-cask.sh
-        cask link list
+    - uses: emacs-eask/setup-eask@master
+      with:
+        version: 'snapshot'
 
     - name: test
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,11 @@ on:
     branches-ignore:
     - 'master'
     - 'main'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,10 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        emacs_version:
+        emacs-version:
           - 26.3
           - 27.2
           - 28.2
@@ -28,7 +29,7 @@ jobs:
 
     - uses: jcs090218/setup-emacs@master
       with:
-        version: ${{ matrix.emacs_version }}
+        version: ${{ matrix.emacs-version }}
 
     - uses: actions/cache@v1
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,15 @@ jobs:
       with:
         version: 'snapshot'
 
-    - name: test
+    - name: Run tests (Unix)
+      if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
+      continue-on-error: ${{ matrix.emacs_version == 'snapshot' }}
       run: |
         make test
+      
+    - name: Run tests (Windows)
+      if: matrix.os == 'windows-latest'
       continue-on-error: ${{ matrix.emacs_version == 'snapshot' }}
+      run: |
+        make test-dos
+      

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 /.cask
+/.eask
+
+/dist
+
 *.elc

--- a/Eask
+++ b/Eask
@@ -1,0 +1,32 @@
+(package "ecukes"
+         "0.7.0"
+         "Cucumber for Emacs")
+
+(website-url "http://github.com/ecukes/ecukes")
+(keywords "test")
+
+(package-file "ecukes.el")
+(package-descriptor "ecukes-pkg.el")
+
+(files "ecukes-*.el" "templates" "bin" "reporters")
+
+(script "test" "echo \"Error: no test specified\" && exit 1")
+
+(source 'gnu)    ; for cl-lib
+(source 'melpa)
+
+(depends-on "emacs" "25")
+(depends-on "f" "0.11.0")
+(depends-on "s" "1.8.0")
+(depends-on "dash" "2.2.0")
+(depends-on "ansi" "0.3.0")
+(depends-on "espuds" "0.2.2")
+(depends-on "commander" "0.6.1")
+
+(development
+ (depends-on "ansi")
+ (depends-on "el-mock")
+ (depends-on "ert-runner")
+ (depends-on "ecukes"))
+
+(setq network-security-level 'low)  ; see https://github.com/jcs090218/setup-emacs-windows/issues/156#issuecomment-932956432

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ FEATURES = $(wildcard features/*.feature features/reporters/*.feature)
 all: test
 
 test: clean-elc unit-test ecukes compile
+# XXX: There is no binary for Windwos yet, so we omit the `ecukes` test
+test-dos: clean-elc unit-test compile
 
 unit-test:
 	$(EASK) install-deps --dev

--- a/Makefile
+++ b/Makefile
@@ -1,37 +1,33 @@
 .PHONY : all test unit-test clean clean-elc ecukes
 
 EMACS ?= emacs
-SRC = $(filter-out %-pkg.el, $(wildcard *.el reporters/*.el))
-ELC = $(SRC:.el=.elc)
 CASK ?= cask
-PKG_DIR := $(shell $(CASK) package-directory)
+EASK ?= eask
 FEATURES = $(wildcard features/*.feature features/reporters/*.feature)
 
 all: test
 
 test: clean-elc unit-test ecukes compile
 
-unit-test: elpa
-	$(CASK) exec ert-runner -L test -L . test/ecukes*.el
+unit-test:
+	$(EASK) install-deps --dev
+	$(EASK) exec ert-runner -L test -L . test/ecukes*.el
 
-elpa: $(PKG_DIR)
-$(PKG_DIR): Cask
-	$(CASK) install
-	$(CASK) link ecukes .
+$(PKG_DIR):
+	$(EASK) link add ecukes .
 	touch $@
 
-compile: $(ELC)
-%.elc: %.el
-	@$(CASK) exec $(EMACS) -Q --script ecukes-byte-compile.el $<
+compile:
+	@$(EASK) compile
 
 clean: clean-elc
 	rm -rf $(PKG_DIR)
 
 clean-elc:
-	rm -rf *.elc test/*.elc reporters/*.elc
+	@$(EASK) clean elc
+	rm -rf test/*.elc reporters/*.elc
 
-ecukes: features/projects/super-project/.cask
-	$(CASK) exec ecukes --script $(FEATURES)
-
-features/projects/super-project/.cask:
-	cd features/projects/super-project && cask
+ecukes:
+	cd features/projects/super-project
+	$(EASK) install-deps --dev
+	$(EASK) exec ecukes --script $(FEATURES)

--- a/README.markdown
+++ b/README.markdown
@@ -1,4 +1,6 @@
-# Ecukes - Cucumber for Emacs [![Build Status](https://api.travis-ci.org/ecukes/ecukes.png?branch=master)](http://travis-ci.org/ecukes/ecukes)
+# Ecukes - Cucumber for Emacs
+[![Build Status](https://api.travis-ci.org/ecukes/ecukes.png?branch=master)](http://travis-ci.org/ecukes/ecukes)
+[![CI](https://github.com/ecukes/ecukes/actions/workflows/test.yml/badge.svg)](https://github.com/ecukes/ecukes/actions/workflows/test.yml)
 
 [<img src="http://img.youtube.com/vi/4VcH4uAQJZI/0.jpg">](https://www.youtube.com/watch?v=4VcH4uAQJZI)
 
@@ -649,9 +651,8 @@ possible). Ecukes is unit tested with a testing framework called Ert
 (Emacs Lisp Regression Testing). But most notably, it's tested using
 Ecukes! :)
 
-To run the tests, you have to install
-[Cask](https://github.com/rejeep/cask.el) if you haven't already. Once
-installed, run the `cask` command to install all dependencies.
+To run the tests, you have to install [Eask][Eask] if you haven't already. Once
+installed, run the `eask` command to install all dependencies.
 
 To run all tests, simply run the `make` command.
 

--- a/ecukes-pkg.el
+++ b/ecukes-pkg.el
@@ -1,7 +1,10 @@
-(define-package "ecukes" "0.7.0" "Cucumber for Emacs."
-  '((commander "0.6.1")
+(define-package "ecukes" "0.7.0" "Cucumber for Emacs"
+  '((emacs "25")
+    (commander "0.6.1")
     (espuds "0.2.2")
     (ansi "0.3.0")
     (dash "2.2.0")
     (s "1.8.0")
-    (f "0.11.0")))
+    (f "0.11.0"))
+  :url "http://github.com/ecukes/ecukes"
+  :keywords '("test"))

--- a/features/projects/super-project/.gitignore
+++ b/features/projects/super-project/.gitignore
@@ -1,4 +1,6 @@
 /.cask
+/.eask
+/dist
 /features/*.feature
 /features/step-definitions/super-project-steps.el
 /.ecukes

--- a/features/projects/super-project/Eask
+++ b/features/projects/super-project/Eask
@@ -6,3 +6,5 @@
 (development
  (depends-on "ecukes")
  (depends-on "espuds"))
+
+(setq network-security-level 'low)  ; see https://github.com/jcs090218/setup-emacs-windows/issues/156#issuecomment-932956432

--- a/features/projects/super-project/Eask
+++ b/features/projects/super-project/Eask
@@ -1,0 +1,8 @@
+(package "super-project" "0.0.1" "...")
+
+(source 'gnu)
+(source 'melpa)
+
+(development
+ (depends-on "ecukes")
+ (depends-on "espuds"))

--- a/test/ecukes-new-test.el
+++ b/test/ecukes-new-test.el
@@ -35,7 +35,7 @@
   "Should create features directory."
   (with-mock
    (with-new-project
-    (mock (make-directory "/path/to/project/features") :times 1)
+    (mock (make-directory (expand-file-name "/path/to/project/features")) :times 1)
     (mock (ecukes-new-message 0 "features") :times 1)
     (ecukes-new-create-root))))
 
@@ -43,8 +43,8 @@
   "Should create step definitions directory and step definition."
   (with-mock
    (with-new-project
-    (mock (make-directory "/path/to/project/features/step-definitions") :times 1)
-    (mock (ecukes-template-write "/path/to/project/features/step-definitions/project-steps.el" *) :times 1)
+    (mock (make-directory (expand-file-name "/path/to/project/features/step-definitions")) :times 1)
+    (mock (ecukes-template-write (expand-file-name "/path/to/project/features/step-definitions/project-steps.el") *) :times 1)
     (stub ecukes-new-message)
     (ecukes-new-create-step-definitions))))
 
@@ -52,8 +52,8 @@
   "Should create support directory with env file."
   (with-mock
    (with-new-project
-    (mock (make-directory "/path/to/project/features/support") :times 1)
-    (mock (ecukes-template-write "/path/to/project/features/support/env.el" * *) :times 1)
+    (mock (make-directory (expand-file-name "/path/to/project/features/support")) :times 1)
+    (mock (ecukes-template-write (expand-file-name "/path/to/project/features/support/env.el") * *) :times 1)
     (stub ecukes-new-message)
     (ecukes-new-create-support))))
 
@@ -61,6 +61,6 @@
   "Should create feature file."
   (with-mock
    (with-new-project
-    (mock (ecukes-template-write "/path/to/project/features/project.feature" *) :times 1)
+    (mock (ecukes-template-write (expand-file-name "/path/to/project/features/project.feature") *) :times 1)
     (mock (ecukes-new-message 2 "project.feature"))
     (ecukes-new-create-feature))))

--- a/test/ecukes-project-test.el
+++ b/test/ecukes-project-test.el
@@ -4,8 +4,8 @@
   "Should return correct project path."
   (with-mock
    (stub file-directory-p => t)
-   (let ((default-directory "/path/to/project"))
-     (should (equal "/path/to/project" (ecukes-project-path))))))
+   (let ((default-directory (expand-file-name "/path/to/project")))
+     (should (equal (expand-file-name "/path/to/project") (ecukes-project-path))))))
 
 (ert-deftest project-name ()
   "Should return correct project name."
@@ -15,14 +15,14 @@
 (ert-deftest project-features-path ()
   "Should return correct project features path."
   (with-project
-   (should (equal "/path/to/project/features" (ecukes-project-features-path)))))
+   (should (equal (expand-file-name "/path/to/project/features") (ecukes-project-features-path)))))
 
 (ert-deftest project-support-path ()
   "Should return correct project support path."
   (with-project
-   (should (equal "/path/to/project/features/support" (ecukes-project-support-path)))))
+   (should (equal (expand-file-name "/path/to/project/features/support") (ecukes-project-support-path)))))
 
 (ert-deftest project-step-definition-path ()
   "Should return correct project step definition path."
   (with-project
-   (should (equal "/path/to/project/features/step-definitions" (ecukes-project-step-definitions-path)))))
+   (should (equal (expand-file-name "/path/to/project/features/step-definitions") (ecukes-project-step-definitions-path)))))


### PR DESCRIPTION
I'm adding test for Legacy Windows.

Since Cask has drop support on Legacy Windows (doesn't work well), Eask is the replacement for it. Hope this is a reasonable change!